### PR TITLE
Adds null pointer check to create Extension Statement Manager

### DIFF
--- a/src/test/java/com/amazon/limitless/assessment/sql/CreateExtensionStmtManagerTest.java
+++ b/src/test/java/com/amazon/limitless/assessment/sql/CreateExtensionStmtManagerTest.java
@@ -84,4 +84,63 @@ public class CreateExtensionStmtManagerTest {
         assertFalse(result.getFeature().isSupported());
         assertEquals(feature.getErrorMessage(), result.getFeature().getErrorMessage());
     }
+
+    @Test
+    public void test_createExtension_withNullContext() {
+        List<StatementResult> resultList = manager.analyzeStatement(null);
+        assertEquals(1, resultList.size());
+        StatementResult result = resultList.get(0);
+        assertFalse(result.getFeature().isSupported());
+        assertEquals("Could not process create extension statement", result.getFeature().getErrorMessage());
+    }
+
+    @Test
+    public void test_createExtension_withNullName() {
+        when(ctx.name()).thenReturn(null);
+        
+        List<StatementResult> resultList = manager.analyzeStatement(ctx);
+        assertEquals(1, resultList.size());
+        StatementResult result = resultList.get(0);
+        assertFalse(result.getFeature().isSupported());
+        assertEquals("Could not process create extension statement", result.getFeature().getErrorMessage());
+    }
+
+    @Test
+    public void test_createExtension_withNullColid() {
+        when(ctx.name()).thenReturn(nameCtx);
+        when(nameCtx.colid()).thenReturn(null);
+        
+        List<StatementResult> resultList = manager.analyzeStatement(ctx);
+        assertEquals(1, resultList.size());
+        StatementResult result = resultList.get(0);
+        assertFalse(result.getFeature().isSupported());
+        assertEquals("Could not process create extension statement", result.getFeature().getErrorMessage());
+    }
+
+    @Test
+    public void test_createExtension_withNullIdentifier() {
+        when(ctx.name()).thenReturn(nameCtx);
+        when(nameCtx.colid()).thenReturn(colidCtx);
+        when(colidCtx.identifier()).thenReturn(null);
+        
+        List<StatementResult> resultList = manager.analyzeStatement(ctx);
+        assertEquals(1, resultList.size());
+        StatementResult result = resultList.get(0);
+        assertFalse(result.getFeature().isSupported());
+        assertEquals("Could not process create extension statement", result.getFeature().getErrorMessage());
+    }
+
+    @Test
+    public void test_createExtension_withNullIdentifierToken() {
+        when(ctx.name()).thenReturn(nameCtx);
+        when(nameCtx.colid()).thenReturn(colidCtx);
+        when(colidCtx.identifier()).thenReturn(identifierCtx);
+        when(identifierCtx.Identifier()).thenReturn(null);
+        
+        List<StatementResult> resultList = manager.analyzeStatement(ctx);
+        assertEquals(1, resultList.size());
+        StatementResult result = resultList.get(0);
+        assertFalse(result.getFeature().isSupported());
+        assertEquals("Could not process create extension statement", result.getFeature().getErrorMessage());
+    }
 }


### PR DESCRIPTION
- Added tests to make sure NPE scenarios are covered

*Issue #, if available:* [#1](https://github.com/aws/limitless-compatibility-assessment-tool/issues/1)

*Description of changes:*
1. Adds a null check to the "create extension manager" analyseStatement
2. Adds additional test coverage on different null inputs

NOTE: I could not run them because I cannot access Amazon's Brazil Build Tool. 

****

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
